### PR TITLE
feat: Support ES2018 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function applyUnassertWithSourceMap (file, encoding, opt) {
     var inMap = file.sourceMap;
     var code = file.contents.toString(encoding);
 
-    var ast = acorn.parse(code, { sourceType: 'module', locations: true });
+    var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module', locations: true });
     var instrumented = escodegen.generate(unassert(ast), {
         file: file.relative,
         sourceMap: file.relative,
@@ -71,7 +71,7 @@ function applyUnassertWithSourceMap (file, encoding, opt) {
 }
 
 function applyUnassertWithoutSourceMap (code) {
-    var ast = acorn.parse(code, { sourceType: 'module' });
+    var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module' });
     return escodegen.generate(unassert(ast));
 }
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "bugs": "https://github.com/unassert-js/gulp-unassert/issues",
   "dependencies": {
-    "acorn": "^4.0.0",
-    "bufferstreams": "^1.1.0",
+    "acorn": "^5.0.0",
+    "bufferstreams": "^2.0.0",
     "buffer-from": "^1.0.0",
     "convert-source-map": "^1.1.2",
     "escodegen": "^1.7.0",
@@ -25,7 +25,7 @@
     "espower-loader": "^1.0.1",
     "event-stream": "^3.3.4",
     "intelli-espower-loader": "^1.0.1",
-    "mocha": "^3.0.2",
+    "mocha": "^5.0.0",
     "power-assert": "^1.4.1"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "bufferstreams": "^2.0.0",
     "buffer-from": "^1.0.0",
     "convert-source-map": "^1.1.2",
-    "escodegen": "^1.7.0",
+    "escodegen": "^1.10.0",
     "gulp-util": "^3.0.0",
     "multi-stage-sourcemap": "^0.2.1",
     "plugin-error": "^1.0.0",

--- a/test/fixtures/es2018/expected.js
+++ b/test/fixtures/es2018/expected.js
@@ -1,0 +1,35 @@
+const urls = [
+    'https://github.com/tc39/proposal-object-rest-spread',
+    'https://github.com/tc39/proposal-regexp-lookbehind',
+    'https://github.com/tc39/proposal-regexp-unicode-property-escapes',
+    'https://github.com/tc39/proposal-promise-finally',
+    'https://github.com/tc39/proposal-async-iteration'
+];
+async function* a() {
+    for (const url of urls) {
+        console.log(`Fetching: ${ url }`);
+        const response = await fetch(url);
+        const iterable = response.text();
+        yield iterable;
+    }
+}
+async function b() {
+    for await (const i of a()) {
+        const title = i.match(/<title>(.+)<\/title>/)[1];
+        console.log(`Title: ${ title }`);
+    }
+}
+b();
+(async () => {
+    for await (const val of asyncIterable) {
+        const obj = {
+            a: 1,
+            b: 2
+        };
+        const expected = {
+            ...obj,
+            c: 3
+        };
+        console.log(val);
+    }
+})();

--- a/test/fixtures/es2018/fixture.js
+++ b/test/fixtures/es2018/fixture.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+
+const urls = [
+    'https://github.com/tc39/proposal-object-rest-spread',
+    'https://github.com/tc39/proposal-regexp-lookbehind',
+    'https://github.com/tc39/proposal-regexp-unicode-property-escapes',
+    'https://github.com/tc39/proposal-promise-finally',
+    'https://github.com/tc39/proposal-async-iteration'
+];
+
+async function * a () {
+    for (const url of urls) {
+        console.log(`Fetching: ${url}`);
+        const response = await fetch(url);
+        const iterable = response.text();
+        yield iterable;
+    }
+}
+
+async function b () {
+    for await (const i of a()) {
+        const title = i.match(/<title>(.+)<\/title>/)[1];
+        assert(title);
+        console.log(`Title: ${title}`);
+    }
+}
+
+b();
+
+
+(async () => {
+    for await (const val of asyncIterable) {
+        const obj = { a: 1, b: 2 };
+        const expected = { ...obj, c: 3 };
+        console.log(val);
+        assert.deepStrictEqual(val, { a: 1, b: 2, c: 3 });
+    }
+})();

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,38 @@ var gutil = require('gulp-util');
 var unassert = require('../');
 
 describe('gulp-unassert', function () {
+
+    it('ES2018 syntax', function (done) {
+        var stream = unassert();
+        var srcStream = new gutil.File({
+            path: process.cwd() + "/test/fixtures/es2018/fixture.js",
+            cwd: process.cwd(),
+            base: process.cwd() + "/test/fixtures/es2018",
+            contents: fs.createReadStream('test/fixtures/es2018/fixture.js')
+        });
+        var expectedFile = new gutil.File({
+            path: process.cwd() + '/test/fixtures/es2018/expected.js',
+            cwd: process.cwd(),
+            base: process.cwd() + '/test/fixtures/es2018',
+            contents: fs.readFileSync('test/fixtures/es2018/expected.js')
+        });
+        stream.on('error', function(err) {
+            assert(!err.message);
+            done();
+        });
+        stream.on('data', function (newFile) {
+            assert(newFile);
+            assert(newFile.contents);
+            newFile.contents.pipe(es.wait(function(err, data) {
+                assert(!err);
+                assert.equal(data.toString('utf-8') + '\n', String(expectedFile.contents));
+                done();
+            }));
+        });
+        stream.write(srcStream);
+        stream.end();
+    });
+
     
     it('should produce expected file via buffer', function (done) {
         var stream = unassert();


### PR DESCRIPTION
Supports ES2018 syntax (for example, object-rest-spread, for-await-of, ...)
requires `escodegen: ^1.10.0` to support for-await-of 