### PR TITLE
Modernize codebase and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "6" # to be removed on "April 2019"
-  - "8" # to be removed on "December 2019"
-  - "9" # to be removed on "June 2018"
   - "10" # to be removed on "April 2021"
+  - "12" # to be removed on "April 2022"
+  - "14" # to be removed on "April 2023"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2018 Takuto Wada, https://github.com/unassert-js/gulp-unassert
+Copyright (c) 2015-2020 Takuto Wada, https://github.com/unassert-js/gulp-unassert
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [CHANGELOG](https://github.com/unassert-js/gulp-unassert/blob/master/CHANGEL
 
 ## Our Support Policy
 
-We support Node under maintenance. In other words, we stop supporting old Node version when [their maintenance ends](https://github.com/nodejs/LTS).
+We support Node under maintenance. In other words, we stop supporting old Node version when [their maintenance ends](https://github.com/nodejs/Release).
 
 This means that any other environment is not supported.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [![unassert][unassert-banner]][unassert-url]
 
-[![NPM version][npm-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
-[![Dependency Status][depstat-image]][depstat-url]
+[![NPM version][npm-image]][npm-url]
+[![Code Style][style-image]][style-url]
 [![License][license-image]][license-url]
 
 
@@ -24,51 +24,88 @@
 - [unassert-cli](https://github.com/unassert-js/unassert-cli): CLI for unassert
 
 
-## Usage
-
-First, install `gulp-unassert` as a devDependencies:
+## Install
 
 ```shell
 npm install --save-dev gulp-unassert
 ```
 
-Then, add it to your `gulpfile.js`:
+## Usage
+
+### gulp 3.x
 
 ```javascript
-var unassert = require('gulp-unassert');
+const unassert = require('gulp-unassert');
 
-gulp.task('build', function () {
-    gulp.src('./src/*.js')
-        .pipe(unassert())
-        .pipe(gulp.dest('./dist'));
+gulp.task('build', () => {
+  gulp.src('./src/*.js')
+    .pipe(unassert())
+    .pipe(gulp.dest('./dist'));
 });
+```
+
+### gulp 4.x
+
+```javascript
+const { src, dest } = require('gulp');
+const unassert = require('gulp-unassert');
+
+function build() {
+  return src('./src/*.js')
+    .pipe(unassert())
+    .pipe(dest('./dist'));
+}
+exports.build = build;
 ```
 
 
 ## Source maps
 
-gulp-unassert can be used with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) to generate source maps for the transformed javascript code. Note that you should `init` gulp-sourcemaps prior to running the gulp-unassert and `write` the source maps after. gulp-unassert works well with some gulp plugins that supports [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps).
+### gulp 3.x
+
+gulp-unassert can be used with [gulp-sourcemaps](https://github.com/gulp-sourcemaps/gulp-sourcemaps) to generate source maps for the transformed javascript code. Note that you should `init` gulp-sourcemaps prior to running the gulp-unassert and `write` the source maps after. gulp-unassert works well with some gulp plugins that supports [gulp-sourcemaps](https://github.com/gulp-sourcemaps/gulp-sourcemaps).
 
 ```javascript
-var unassert = require('gulp-unassert');
-var coffee = require('gulp-coffee');
-var concat = require('gulp-concat');
-var sourcemaps = require('gulp-sourcemaps');
+const unassert = require('gulp-unassert');
+const coffee = require('gulp-coffee');
+const concat = require('gulp-concat');
+const sourcemaps = require('gulp-sourcemaps');
 
-gulp.task('build', function () {
-    // compile, instrument then concatinate
-    gulp.src('./src/**/*.coffee')
-        .pipe(sourcemaps.init())
-        .pipe(coffee({bare: true}))
-        .pipe(unassert())
-        .pipe(concat('bundle.js'))
-        .pipe(sourcemaps.write())
-        .pipe(gulp.dest('./build'));
-    // will write the source maps inline in the code
+gulp.task('build', () => {
+  // compile, instrument then concatinate
+  gulp.src('./src/**/*.coffee')
+    .pipe(sourcemaps.init())
+    .pipe(coffee({bare: true}))
+    .pipe(unassert())
+    .pipe(concat('bundle.js'))
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest('./build'));
+  // will write the source maps inline in the code
 });
 ```
 
-For more information, see [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps).
+For more information, see [gulp-sourcemaps](https://github.com/gulp-sourcemaps/gulp-sourcemaps).
+
+
+### gulp 4.x
+
+In gulp 4, sourcemaps are built-in by default.
+
+```javascript
+const { src, dest } = require('gulp');
+const unassert = require('gulp-unassert');
+const coffee = require('gulp-coffee');
+const concat = require('gulp-concat');
+
+function build() {
+  return src('./src/*.coffee', { sourcemaps: true })
+    .pipe(coffee({ bare: true }))
+    .pipe(unassert())
+    .pipe(concat('bundle.js'))
+    .pipe(dest('./build'));
+}
+exports.build = build;
+```
 
 
 ## Changelog
@@ -104,8 +141,8 @@ Licensed under the [MIT](https://github.com/unassert-js/gulp-unassert/blob/maste
 [travis-url]: https://travis-ci.org/unassert-js/gulp-unassert
 [travis-image]: https://secure.travis-ci.org/unassert-js/gulp-unassert.svg?branch=master
 
-[depstat-url]: https://gemnasium.com/unassert-js/gulp-unassert
-[depstat-image]: https://gemnasium.com/unassert-js/gulp-unassert.svg
-
 [license-url]: https://github.com/unassert-js/gulp-unassert/blob/master/LICENSE-MIT
 [license-image]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat
+
+[style-url]: https://github.com/Flet/semistandard
+[style-image]: https://img.shields.io/badge/code%20style-semistandard-brightgreen.svg

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * gulp-unassert
  *   Gulp plugin for unassert
  *     Encourages programming with assertions by providing tools to compile them away.
- * 
+ *
  * https://github.com/unassert-js/gulp-unassert
  *
  * Copyright (c) 2015-2018 Takuto Wada
@@ -22,94 +22,94 @@ var applySourceMap = require('vinyl-sourcemaps-apply');
 var convert = require('convert-source-map');
 var transfer = require('multi-stage-sourcemap').transfer;
 
-function mergeSourceMap(incomingSourceMap, outgoingSourceMap) {
-    if (typeof outgoingSourceMap === 'string' || outgoingSourceMap instanceof String) {
-        outgoingSourceMap = JSON.parse(outgoingSourceMap);
-    }
-    if (!incomingSourceMap) {
-        return outgoingSourceMap;
-    }
-    return JSON.parse(transfer({fromSourceMap: outgoingSourceMap, toSourceMap: incomingSourceMap}));
+function mergeSourceMap (incomingSourceMap, outgoingSourceMap) {
+  if (typeof outgoingSourceMap === 'string' || outgoingSourceMap instanceof String) {
+    outgoingSourceMap = JSON.parse(outgoingSourceMap);
+  }
+  if (!incomingSourceMap) {
+    return outgoingSourceMap;
+  }
+  return JSON.parse(transfer({ fromSourceMap: outgoingSourceMap, toSourceMap: incomingSourceMap }));
 }
 
 function overwritePropertyIfExists (name, from, to) {
-    if (from.hasOwnProperty(name)) {
-        to.setProperty(name, from[name]);
-    }
+  if (Object.prototype.hasOwnProperty.call(from, name)) {
+    to.setProperty(name, from[name]);
+  }
 }
 
 function applyUnassertWithSourceMap (file, encoding, opt) {
-    var inMap = file.sourceMap;
-    var code = file.contents.toString(encoding);
+  var inMap = file.sourceMap;
+  var code = file.contents.toString(encoding);
 
-    var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module', locations: true });
-    var instrumented = escodegen.generate(unassert(ast), {
-        file: file.relative,
-        sourceMap: file.relative,
-        sourceMapWithCode: true
-    });
-    var outMap = convert.fromJSON(instrumented.map.toString());
-    overwritePropertyIfExists('sources', inMap, outMap);
-    overwritePropertyIfExists('sourcesContent', inMap, outMap);
-    overwritePropertyIfExists('sourceRoot', inMap, outMap);
+  var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module', locations: true });
+  var instrumented = escodegen.generate(unassert(ast), {
+    file: file.relative,
+    sourceMap: file.relative,
+    sourceMapWithCode: true
+  });
+  var outMap = convert.fromJSON(instrumented.map.toString());
+  overwritePropertyIfExists('sources', inMap, outMap);
+  overwritePropertyIfExists('sourcesContent', inMap, outMap);
+  overwritePropertyIfExists('sourceRoot', inMap, outMap);
 
-    var reMap;
-    if (inMap.mappings === '') {
-        // when incoming SourceMap is an initial sourceMap created by gulp-sourcemaps
-        applySourceMap(file, outMap.toJSON());
-        reMap = convert.fromObject(file.sourceMap);
-    } else {
-        reMap = convert.fromObject(mergeSourceMap(inMap, outMap.toJSON()));
-    }
-    overwritePropertyIfExists('sources', inMap, reMap);
-    overwritePropertyIfExists('sourcesContent', inMap, reMap);
-    overwritePropertyIfExists('sourceRoot', inMap, reMap);
-    overwritePropertyIfExists('file', inMap, reMap);
+  var reMap;
+  if (inMap.mappings === '') {
+    // when incoming SourceMap is an initial sourceMap created by gulp-sourcemaps
+    applySourceMap(file, outMap.toJSON());
+    reMap = convert.fromObject(file.sourceMap);
+  } else {
+    reMap = convert.fromObject(mergeSourceMap(inMap, outMap.toJSON()));
+  }
+  overwritePropertyIfExists('sources', inMap, reMap);
+  overwritePropertyIfExists('sourcesContent', inMap, reMap);
+  overwritePropertyIfExists('sourceRoot', inMap, reMap);
+  overwritePropertyIfExists('file', inMap, reMap);
 
-    file.contents = bufferFrom(instrumented.code);
-    file.sourceMap = reMap.toObject();
+  file.contents = bufferFrom(instrumented.code);
+  file.sourceMap = reMap.toObject();
 }
 
 function applyUnassertWithoutSourceMap (code) {
-    var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module' });
-    return escodegen.generate(unassert(ast));
+  var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module' });
+  return escodegen.generate(unassert(ast));
 }
 
 function transform (file, encoding, opt) {
-    if (file.sourceMap) {
-        applyUnassertWithSourceMap(file, encoding, opt);
-    } else {
-        file.contents = bufferFrom(applyUnassertWithoutSourceMap(file.contents.toString(encoding)));
-    }
+  if (file.sourceMap) {
+    applyUnassertWithSourceMap(file, encoding, opt);
+  } else {
+    file.contents = bufferFrom(applyUnassertWithoutSourceMap(file.contents.toString(encoding)));
+  }
 }
 
 module.exports = function (opt) {
-    return through.obj(function (file, encoding, callback) {
-        encoding = encoding || 'utf8';
-        if (file.isNull()) {
-            this.push(file);
-        } else if (file.isBuffer()) {
-            try {
-                transform(file, encoding, opt);
-                this.push(file);
-            } catch (err) {
-                return callback(new PluginError('gulp-unassert', err, {showStack: true}));
-            }
-        } else if (file.isStream()) {
-            file.contents = file.contents.pipe(new BufferStreams(function(err, buf, cb) {
-                if(err) {
-                    cb(new PluginError('gulp-unassert', err, {showStack: true}));
-                } else {
-                    try {
-                        var modifiedCode = applyUnassertWithoutSourceMap(buf.toString(encoding));
-                        cb(null, bufferFrom(modifiedCode));
-                    } catch (innerError) {
-                        return callback(new PluginError('gulp-unassert', innerError, {showStack: true}));
-                    }
-                }
-            }));
-            this.push(file);
+  return through.obj(function (file, encoding, callback) {
+    encoding = encoding || 'utf8';
+    if (file.isNull()) {
+      this.push(file);
+    } else if (file.isBuffer()) {
+      try {
+        transform(file, encoding, opt);
+        this.push(file);
+      } catch (err) {
+        return callback(new PluginError('gulp-unassert', err, { showStack: true }));
+      }
+    } else if (file.isStream()) {
+      file.contents = file.contents.pipe(new BufferStreams(function (err, buf, cb) {
+        if (err) {
+          cb(new PluginError('gulp-unassert', err, { showStack: true }));
+        } else {
+          try {
+            var modifiedCode = applyUnassertWithoutSourceMap(buf.toString(encoding));
+            cb(null, bufferFrom(modifiedCode));
+          } catch (innerError) {
+            return callback(new PluginError('gulp-unassert', innerError, { showStack: true }));
+          }
         }
-        callback();
-    });
+      }));
+      this.push(file);
+    }
+    callback();
+  });
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  *
  * https://github.com/unassert-js/gulp-unassert
  *
- * Copyright (c) 2015-2018 Takuto Wada
+ * Copyright (c) 2015-2020 Takuto Wada
  * Licensed under the MIT license.
  *   https://github.com/unassert-js/gulp-unassert/blob/master/LICENSE-MIT
  */

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function applyUnassertWithSourceMap (file, encoding, opt) {
   var inMap = file.sourceMap;
   var code = file.contents.toString(encoding);
 
-  var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module', locations: true });
+  var ast = acorn.parse(code, { ecmaVersion: 2020, sourceType: 'module', locations: true });
   var instrumented = escodegen.generate(unassert(ast), {
     file: file.relative,
     sourceMap: file.relative,
@@ -70,7 +70,7 @@ function applyUnassertWithSourceMap (file, encoding, opt) {
 }
 
 function applyUnassertWithoutSourceMap (code) {
-  var ast = acorn.parse(code, { ecmaVersion: 2018, sourceType: 'module' });
+  var ast = acorn.parse(code, { ecmaVersion: 2020, sourceType: 'module' });
   return escodegen.generate(unassert(ast));
 }
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@
 var unassert = require('unassert');
 var through = require('through2');
 var PluginError = require('plugin-error');
-var bufferFrom = require('buffer-from');
 var BufferStreams = require('bufferstreams');
 var acorn = require('acorn');
 var escodegen = require('escodegen');
@@ -66,7 +65,7 @@ function applyUnassertWithSourceMap (file, encoding, opt) {
   overwritePropertyIfExists('sourceRoot', inMap, reMap);
   overwritePropertyIfExists('file', inMap, reMap);
 
-  file.contents = bufferFrom(instrumented.code);
+  file.contents = Buffer.from(instrumented.code);
   file.sourceMap = reMap.toObject();
 }
 
@@ -79,7 +78,7 @@ function transform (file, encoding, opt) {
   if (file.sourceMap) {
     applyUnassertWithSourceMap(file, encoding, opt);
   } else {
-    file.contents = bufferFrom(applyUnassertWithoutSourceMap(file.contents.toString(encoding)));
+    file.contents = Buffer.from(applyUnassertWithoutSourceMap(file.contents.toString(encoding)));
   }
 }
 
@@ -102,7 +101,7 @@ module.exports = function (opt) {
         } else {
           try {
             var modifiedCode = applyUnassertWithoutSourceMap(buf.toString(encoding));
-            cb(null, bufferFrom(modifiedCode));
+            cb(null, Buffer.from(modifiedCode));
           } catch (innerError) {
             return callback(new PluginError('gulp-unassert', innerError, { showStack: true }));
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
     },
     "acorn-es7-plugin": {
       "version": "1.1.7",
@@ -201,14 +201,15 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "bufferstreams": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-2.0.1.tgz",
-      "integrity": "sha512-ZswyIoBfFb3cVDsnZLLj2IDJ/0ppYdil/v2EGlZXvoefO689FokEmFEldhN5dV7R2QBxFneqTJOMIpfqhj+n0g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-3.0.0.tgz",
+      "integrity": "sha512-Qg0ggJUWJq90vtg4lDsGN9CDWvzBMQxhiEkSOD/sJfYt6BLect3eV1/S6K7SCSKJ34n60rf6U5eUPmQENVE4UA==",
       "requires": {
-        "readable-stream": "^2.3.6"
+        "readable-stream": "^3.4.0"
       }
     },
     "call-matcher": {
@@ -364,6 +365,38 @@
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
         "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "color-convert": {
@@ -397,19 +430,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "contains-path": {
@@ -424,6 +444,13 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "requires": {
         "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "core-js": {
@@ -435,7 +462,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1182,6 +1210,32 @@
         "multi-stage-sourcemap": "^0.2.1",
         "path-is-absolute": "^1.0.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
+        "multi-stage-sourcemap": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz",
+          "integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU=",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.1.34"
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
       }
     },
     "espree": {
@@ -1193,14 +1247,6 @@
         "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -1719,7 +1765,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1923,9 +1970,9 @@
       "dev": true
     },
     "multi-stage-sourcemap": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz",
-      "integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.3.1.tgz",
+      "integrity": "sha512-UiTLYjqeIoVnJHyWGskwMKIhtZKK9uXUjSTWuwatarrc0d2H/6MAVFdwvEA/aKOHamIn7z4tfvxjz+FYucFpNQ==",
       "requires": {
         "source-map": "^0.1.34"
       },
@@ -2359,6 +2406,12 @@
         "estraverse": "^4.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
         "espurify": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
@@ -2462,7 +2515,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -2560,17 +2614,13 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -2677,9 +2727,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2762,19 +2812,6 @@
         "standard-json": "^1.0.0",
         "strip-ansi": "^4.0.0",
         "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "source-map": {
@@ -2927,11 +2964,11 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "stringifier": {
@@ -3028,12 +3065,11 @@
       "dev": true
     },
     "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "2 || 3"
       }
     },
     "tmp": {
@@ -3110,13 +3146,6 @@
         "estraverse": "^4.1.0",
         "esutils": "^2.0.2",
         "object-assign": "^4.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
-        }
       }
     },
     "uniq": {
@@ -3281,7 +3310,8 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,32 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
@@ -14,6 +40,24 @@
       "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
       "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s=",
       "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -27,6 +71,12 @@
       "requires": {
         "ansi-wrap": "^0.1.0"
       }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -89,10 +139,27 @@
       "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
+      }
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -160,6 +227,12 @@
       "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
       "dev": true
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -188,6 +261,12 @@
         }
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "chokidar": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
@@ -203,6 +282,21 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
     },
     "cliui": {
       "version": "5.0.0",
@@ -293,6 +387,37 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -312,6 +437,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -330,6 +468,12 @@
       "requires": {
         "ms": "^2.1.1"
       }
+    },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
@@ -363,6 +507,28 @@
         "object-keys": "^1.0.12"
       }
     },
+    "deglob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -374,6 +540,15 @@
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
       "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -420,6 +595,15 @@
       "requires": {
         "call-signature": "0.0.2",
         "core-js": "^2.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -602,6 +786,318 @@
         "estraverse": "^4.1.1"
       }
     },
+    "eslint": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
+      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-semistandard": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-15.0.0.tgz",
+      "integrity": "sha512-volIMnosUvzyxGkYUA5QvwkahZZLeUx7wcS0+7QumPn+MMEBbV6P7BY1yukamMst0w3Et3QZlCjQEwQ8tQ6nug==",
+      "dev": true
+    },
+    "eslint-config-standard": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+      "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^2.0.0",
+        "eslint-utils": "^1.4.2",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
     "espower": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/espower/-/espower-2.1.2.tgz",
@@ -688,6 +1184,25 @@
         "xtend": "^4.0.0"
       }
     },
+    "espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -697,6 +1212,23 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-2.0.1.tgz",
       "integrity": "sha512-7w/dUrReI/QbJFHRwfomTlkQOXaB1NuCrBRn5Y26HXn5gvh18/19AgLbayVrNxXQfkckvgrJloWyvZDuJ7dhEA=="
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
+      }
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -768,10 +1300,51 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -781,6 +1354,12 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "3.0.0",
@@ -799,6 +1378,23 @@
       "requires": {
         "is-buffer": "~2.0.3"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "from": {
       "version": "0.1.7",
@@ -824,10 +1420,22 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
     },
     "glob": {
@@ -852,6 +1460,18 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -884,6 +1504,43 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -905,6 +1562,44 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "intelli-espower-loader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/intelli-espower-loader/-/intelli-espower-loader-1.0.1.tgz",
@@ -918,6 +1613,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -995,6 +1696,12 @@
         "has": "^1.0.3"
       }
     },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -1025,6 +1732,12 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -1035,6 +1748,34 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+      "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1042,6 +1783,18 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -1069,6 +1822,15 @@
         "chalk": "^2.4.2"
       }
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "map-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
@@ -1083,6 +1845,12 @@
       "requires": {
         "estraverse": "^4.0.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1172,10 +1940,28 @@
         }
       }
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-environment-flags": {
@@ -1186,6 +1972,18 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -1229,6 +2027,30 @@
         "object-keys": "^1.0.11"
       }
     },
+    "object.entries": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
@@ -1239,6 +2061,18 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1246,6 +2080,15 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
       }
     },
     "optionator": {
@@ -1260,6 +2103,12 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -1285,6 +2134,24 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1296,6 +2163,27 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.0.0"
+      }
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -1311,6 +2199,118 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
     },
     "plugin-error": {
       "version": "1.0.1",
@@ -1464,6 +2464,101 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1496,6 +2591,12 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -1520,10 +2621,89 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semistandard": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-14.2.0.tgz",
+      "integrity": "sha512-mQ0heTpbW7WWBXKOIqitlfEcAZhgGTwaHr1zzv70PnZZc53J+4u31+vLUEsh2oKVWfVgcjrykT2hz02B1Cfaaw==",
+      "dev": true,
+      "requires": {
+        "eslint": "~6.4.0",
+        "eslint-config-semistandard": "15.0.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-config-standard-jsx": "8.1.0",
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~10.0.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "^12.0.0"
+      }
     },
     "semver": {
       "version": "5.7.1",
@@ -1536,6 +2716,66 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snazzy": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/snazzy/-/snazzy-8.0.0.tgz",
+      "integrity": "sha512-59GS69hQD8FvJoNGeDz8aZtbYhkCFxCPQB1BFzAWiVVwPmS/J6Vjaku0k6tGNsdSxQ0kAlButdkn8bPR2hLcBw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "inherits": "^2.0.1",
+        "minimist": "^1.1.1",
+        "readable-stream": "^3.0.2",
+        "standard-json": "^1.0.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -1560,6 +2800,38 @@
         }
       }
     },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -1574,6 +2846,27 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "standard-engine": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.1.tgz",
+      "integrity": "sha512-XtR9NfoTqvHkWQCwL1aLMwXw1Qxy5s4rdSIqetgBNw+8faNbQ+BbB49hPhKXjxxfC4yg+fpH0lx/T5fuUbpDcQ==",
+      "dev": true,
+      "requires": {
+        "deglob": "^4.0.1",
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.2.5",
+        "pkg-conf": "^3.1.0"
+      }
+    },
+    "standard-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.1.0.tgz",
+      "integrity": "sha512-nkonX+n5g3pyVBvJZmvRlFtT/7JyLbNh4CtrYC3Qfxihgs8PKX52f6ONKQXORStuBWJ5PI83EUrNXme7LKfiTQ==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^2.0.0"
+      }
     },
     "stream-combiner": {
       "version": "0.2.2",
@@ -1661,6 +2954,12 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1676,6 +2975,52 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1689,6 +3034,15 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-regex-range": {
@@ -1706,6 +3060,12 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "dev": true
+    },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -1720,10 +3080,22 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
+    },
     "type-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
       "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "unassert": {
@@ -1747,6 +3119,12 @@
         }
       }
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "universal-deep-strict-equal": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
@@ -1758,10 +3136,35 @@
         "object-keys": "^1.0.0"
       }
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "vinyl": {
       "version": "2.2.0",
@@ -1865,6 +3268,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,44 @@
         "ansi-wrap": "^0.1.0"
       }
     },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -66,6 +100,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -76,6 +116,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -83,9 +132,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bufferstreams": {
       "version": "2.0.1",
@@ -96,13 +145,12 @@
       }
     },
     "call-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-2.0.0.tgz",
+      "integrity": "sha512-CIDC5wZZfZ2VjZu849WQckS58Z3pJXFfRaSjNjgo/q3in5zxkhTwVL83vttgtmvyLG7TuDlLlBya7SKP6CjDIA==",
       "requires": {
-        "core-js": "^2.0.0",
         "deep-equal": "^1.0.0",
-        "espurify": "^1.6.0",
+        "espurify": "^2.0.0",
         "estraverse": "^4.0.0"
       }
     },
@@ -112,10 +160,93 @@
       "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-buffer": {
@@ -131,9 +262,9 @@
       "dev": true
     },
     "cloneable-readable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -141,10 +272,19 @@
         "readable-stream": "^2.3.5"
       }
     },
-    "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "concat-map": {
@@ -154,14 +294,18 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -169,27 +313,42 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -197,13 +356,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "object-keys": "^1.0.12"
       }
     },
     "diff": {
@@ -213,9 +370,9 @@
       "dev": true
     },
     "diff-match-patch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.1.tgz",
-      "integrity": "sha512-A0QEhr4PxGUMEtKxd6X+JLnOTFd3BfIPSDpsc4dMvj+CbSaErDwTpoTo/nFJDMSrjxLW4BiNq+FbNisAAHhWeQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
+      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==",
       "dev": true
     },
     "duplexer": {
@@ -225,19 +382,25 @@
       "dev": true
     },
     "eastasianwidth": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
-      "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
     "empower": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
-      "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/empower/-/empower-1.3.1.tgz",
+      "integrity": "sha512-uB6/ViBaawOO/uujFADTK3SqdYlxYNn+N4usK9MRKZ4Hbn/1QSy8k2PezxCA2/+JGbF8vd/eOfghZ90oOSDZCA==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
-        "empower-core": "^0.6.2"
+        "empower-core": "^1.2.0"
       }
     },
     "empower-assert": {
@@ -250,24 +413,52 @@
       }
     },
     "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
+      "integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
         "core-js": "^2.0.0"
       }
     },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "es5-ext": {
-      "version": "0.10.45",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
       }
     },
     "es6-iterator": {
@@ -306,27 +497,39 @@
         "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "dev": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        }
       }
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
     },
@@ -340,11 +543,32 @@
         "esprima": "^2.0.0"
       },
       "dependencies": {
+        "call-matcher": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
+          "integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "deep-equal": "^1.0.0",
+            "espurify": "^1.6.0",
+            "estraverse": "^4.0.0"
+          }
+        },
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
+        },
+        "espurify": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+          "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.0.0"
+          }
         }
       }
     },
@@ -355,11 +579,11 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
-      "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
@@ -379,9 +603,9 @@
       }
     },
     "espower": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/espower/-/espower-2.1.1.tgz",
-      "integrity": "sha512-F4TY1qYJB1aUyzB03NsZksZzUQmQoEBaTUjRJGR30GxbkbjKI41NhCyYjrF+bGgWN7x/ZsczYppRpz/0WdI0ug==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/espower/-/espower-2.1.2.tgz",
+      "integrity": "sha512-2qa3aEFtcgPB782jTKDPu82hOdw8+zJsWdOn12Tey8XlexHTqsYUIdLC2B7cUECENXly0vZblH1CEZcqttPNjw==",
       "dev": true,
       "requires": {
         "array-find": "^1.0.0",
@@ -392,10 +616,18 @@
         "espurify": "^1.3.0",
         "estraverse": "^4.1.0",
         "source-map": "^0.5.0",
-        "type-name": "^2.0.0",
-        "xtend": "^4.0.0"
+        "type-name": "^2.0.0"
       },
       "dependencies": {
+        "espurify": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+          "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -438,17 +670,17 @@
       }
     },
     "espower-source": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/espower-source/-/espower-source-2.2.0.tgz",
-      "integrity": "sha1-fgBSVa5HtcE2RIZEs/PYAtUD91I=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/espower-source/-/espower-source-2.3.0.tgz",
+      "integrity": "sha512-Wc4kC4zUAEV7Qt31JRPoBUc5jjowHRylml2L2VaDQ1XEbnqQofGWx+gPR03TZAPokAMl5dqyL36h3ITyMXy3iA==",
       "dev": true,
       "requires": {
         "acorn": "^5.0.0",
         "acorn-es7-plugin": "^1.0.10",
         "convert-source-map": "^1.1.1",
         "empower-assert": "^1.0.0",
-        "escodegen": "^1.6.1",
-        "espower": "^2.0.0",
+        "escodegen": "^1.10.0",
+        "espower": "^2.1.1",
         "estraverse": "^4.0.0",
         "merge-estraverse-visitors": "^1.0.0",
         "multi-stage-sourcemap": "^0.2.1",
@@ -457,17 +689,14 @@
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "espurify": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
-      "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
-      "requires": {
-        "core-js": "^2.0.0"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-2.0.1.tgz",
+      "integrity": "sha512-7w/dUrReI/QbJFHRwfomTlkQOXaB1NuCrBRn5Y26HXn5gvh18/19AgLbayVrNxXQfkckvgrJloWyvZDuJ7dhEA=="
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -479,14 +708,14 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -499,18 +728,35 @@
       }
     },
     "event-stream": {
-      "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "dev": true
+        }
       }
     },
     "extend-shallow": {
@@ -527,11 +773,32 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
     },
     "from": {
       "version": "0.1.7",
@@ -545,10 +812,28 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -559,11 +844,28 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-flag": {
       "version": "3.0.0",
@@ -571,10 +873,15 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "indexof": {
@@ -594,9 +901,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "intelli-espower-loader": {
       "version": "1.0.1",
@@ -607,6 +914,36 @@
         "espower-loader": "^1.0.0"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+    },
     "is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -615,12 +952,55 @@
         "is-plain-object": "^2.0.4"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "requires": {
+        "has-symbols": "^1.0.1"
       }
     },
     "is-url": {
@@ -634,10 +1014,26 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -648,10 +1044,35 @@
         "type-check": "~0.3.2"
       }
     },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
     "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
     },
     "merge-estraverse-visitors": {
@@ -673,43 +1094,64 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
       "dev": true,
       "requires": {
+        "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
         "growl": "1.10.5",
-        "he": "1.1.1",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+          "dev": true
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
     "multi-stage-sourcemap": {
@@ -736,16 +1178,66 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -757,17 +1249,47 @@
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -784,6 +1306,12 @@
         "through": "~2.3"
       }
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
     "plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -796,53 +1324,56 @@
       }
     },
     "power-assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.5.0.tgz",
-      "integrity": "sha512-WaWSw+Ts283o6dzxW1BxIxoaHok7aSSGx4SaR6dW62Pk31ynv9DERDieuZpPYv5XaJ+H+zdcOaJQ+PvlasAOVw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.6.1.tgz",
+      "integrity": "sha512-VWkkZV6Y+W8qLX/PtJu2Ur2jDPIs0a5vbP0TpKeybNcIXmT4vcKoVkyTp5lnQvTpY/DxacAZ4RZisHRHLJcAZQ==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
-        "empower": "^1.2.3",
-        "power-assert-formatter": "^1.3.1",
+        "empower": "^1.3.1",
+        "power-assert-formatter": "^1.4.1",
         "universal-deep-strict-equal": "^1.2.1",
         "xtend": "^4.0.0"
       }
     },
     "power-assert-context-formatter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
-      "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.2.0.tgz",
+      "integrity": "sha512-HLNEW8Bin+BFCpk/zbyKwkEu9W8/zThIStxGo7weYcFkKgMuGCHUJhvJeBGXDZf0Qm2xis4pbnnciGZiX0EpSg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
-        "power-assert-context-traversal": "^1.1.1"
+        "power-assert-context-traversal": "^1.2.0"
       }
     },
     "power-assert-context-reducer-ast": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.2.tgz",
-      "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.2.0.tgz",
+      "integrity": "sha512-EgOxmZ/Lb7tw4EwSKX7ZnfC0P/qRZFEG28dx/690qvhmOJ6hgThYFm5TUWANDLK5NiNKlPBi5WekVGd2+5wPrw==",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.0",
+        "acorn": "^5.0.0",
         "acorn-es7-plugin": "^1.0.12",
         "core-js": "^2.0.0",
         "espurify": "^1.6.0",
         "estraverse": "^4.2.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
+        "espurify": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+          "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.0.0"
+          }
         }
       }
     },
     "power-assert-context-traversal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
-      "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.2.0.tgz",
+      "integrity": "sha512-NFoHU6g2umNajiP2l4qb0BRWD773Aw9uWdWYH9EQsVwIZnog5bd2YYLFCVvaxWpwNzWeEfZIon2xtyc63026pQ==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -865,13 +1396,13 @@
       }
     },
     "power-assert-renderer-assertion": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
-      "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.2.0.tgz",
+      "integrity": "sha512-3F7Q1ZLmV2ZCQv7aV7NJLNK9G7QsostrhOU7U0RhEQS/0vhEqrRg2jEJl1jtUL4ZyL2dXUlaaqrmPv5r9kRvIg==",
       "dev": true,
       "requires": {
         "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1"
+        "power-assert-util-string-width": "^1.2.0"
       }
     },
     "power-assert-renderer-base": {
@@ -881,9 +1412,9 @@
       "dev": true
     },
     "power-assert-renderer-comparison": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
-      "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.2.0.tgz",
+      "integrity": "sha512-7c3RKPDBKK4E3JqdPtYRE9cM8AyX4LC4yfTvvTYyx8zSqmT5kJnXwzR0yWQLOavACllZfwrAGQzFiXPc5sWa+g==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -894,33 +1425,33 @@
       }
     },
     "power-assert-renderer-diagram": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
-      "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.2.0.tgz",
+      "integrity": "sha512-JZ6PC+DJPQqfU6dwSmpcoD7gNnb/5U77bU5KgNwPPa+i1Pxiz6UuDeM3EUBlhZ1HvH9tMjI60anqVyi5l2oNdg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
         "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1",
+        "power-assert-util-string-width": "^1.2.0",
         "stringifier": "^1.3.0"
       }
     },
     "power-assert-renderer-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.1.tgz",
-      "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.2.0.tgz",
+      "integrity": "sha512-/oaVrRbeOtGoyyd7e4IdLP/jIIUFJdqJtsYzP9/88R39CMnfF/S/rUc8ZQalENfUfQ/wQHu+XZYRMaCEZmEesg==",
       "dev": true,
       "requires": {
         "power-assert-renderer-base": "^1.1.1"
       }
     },
     "power-assert-util-string-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
-      "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.2.0.tgz",
+      "integrity": "sha512-lX90G0igAW0iyORTILZ/QjZWsa1MZ6VVY3L0K86e2eKun3S4LKPH4xZIl8fdeMYLfOjkaszbNSzf1uugLeAm2A==",
       "dev": true,
       "requires": {
-        "eastasianwidth": "^0.1.1"
+        "eastasianwidth": "^0.2.0"
       }
     },
     "prelude-ls": {
@@ -929,14 +1460,14 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -947,6 +1478,24 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -954,15 +1503,39 @@
       "dev": true
     },
     "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -988,21 +1561,76 @@
       }
     },
     "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
         "through": "2"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
@@ -1014,9 +1642,9 @@
       }
     },
     "stringifier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
-      "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.4.0.tgz",
+      "integrity": "sha512-cNsMOqqrcbLcHTXEVmkw9y0fwDwkdgtZwlfyolzpQDoAE1xdNGhQhxBUfiDvvZIKl1hnUEgMv66nHwtMz3OjPw==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -1024,10 +1652,25 @@
         "type-name": "^2.0.1"
       }
     },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
@@ -1040,18 +1683,33 @@
       "dev": true
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
-        "readable-stream": "^2.1.5",
+        "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
     "type-check": {
@@ -1069,23 +1727,23 @@
       "dev": true
     },
     "unassert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/unassert/-/unassert-1.5.1.tgz",
-      "integrity": "sha1-y8iOw4dBfFpeTALTzQe+mL11/3Y=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unassert/-/unassert-1.6.0.tgz",
+      "integrity": "sha512-GoMtWTwGSxSFuRD0NKmbjlx3VJkgvSogzDzMPpJXYmBZv6MIWButsyMqEYhMx3NI4osXACcZA9mXiBteXyJtRw==",
       "requires": {
-        "acorn": "^4.0.0",
-        "call-matcher": "^1.0.1",
+        "acorn": "^7.0.0",
+        "call-matcher": "^2.0.0",
         "deep-equal": "^1.0.0",
-        "espurify": "^1.3.0",
+        "espurify": "^2.0.1",
         "estraverse": "^4.1.0",
         "esutils": "^2.0.2",
         "object-assign": "^4.1.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
         }
       }
     },
@@ -1106,9 +1764,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vinyl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-      "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "dev": true,
       "requires": {
         "clone": "^2.1.1",
@@ -1134,10 +1792,73 @@
         }
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1146,9 +1867,82 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "devDependencies": {
     "espower-loader": "^1.0.1",
-    "event-stream": "^3.3.4",
+    "event-stream": "^4.0.0",
     "intelli-espower-loader": "^1.0.1",
-    "mocha": "^5.0.0",
+    "mocha": "^7.0.0",
     "power-assert": "^1.4.1",
     "vinyl": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "intelli-espower-loader": "^1.0.1",
     "mocha": "^7.0.0",
     "power-assert": "^1.4.1",
+    "semistandard": "^14.2.0",
+    "snazzy": "^8.0.0",
     "vinyl": "^2.0.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,17 @@
     "url": "http://github.com/unassert-js/gulp-unassert.git"
   },
   "scripts": {
-    "test": "mocha --require intelli-espower-loader"
+    "lint": "semistandard --verbose index.js 'test/*.js' | snazzy",
+    "fmt": "semistandard --fix index.js 'test/*.js'",
+    "test:unit": "mocha --require intelli-espower-loader",
+    "test": "npm run lint && npm run test:unit"
+  },
+  "semistandard": {
+    "globals": [
+      "describe",
+      "context",
+      "beforeEach",
+      "it"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,14 +9,13 @@
   },
   "bugs": "https://github.com/unassert-js/gulp-unassert/issues",
   "dependencies": {
-    "acorn": "^5.0.0",
-    "buffer-from": "^1.0.0",
-    "bufferstreams": "^2.0.0",
+    "acorn": "^7.0.0",
+    "bufferstreams": "^3.0.0",
     "convert-source-map": "^1.1.2",
     "escodegen": "^1.10.0",
-    "multi-stage-sourcemap": "^0.2.1",
+    "multi-stage-sourcemap": "^0.3.1",
     "plugin-error": "^1.0.0",
-    "through2": "^2.0.0",
+    "through2": "^3.0.0",
     "unassert": "^1.3.1",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "url": "http://github.com/unassert-js/gulp-unassert.git"
   },
   "scripts": {
-    "lint": "semistandard --verbose index.js 'test/*.js' | snazzy",
     "fmt": "semistandard --fix index.js 'test/*.js'",
-    "test:unit": "mocha --require intelli-espower-loader",
-    "test": "npm run lint && npm run test:unit"
+    "lint": "semistandard --verbose index.js 'test/*.js' | snazzy",
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "mocha --require intelli-espower-loader"
   },
   "semistandard": {
     "globals": [

--- a/test/fixtures/es2019/expected.js
+++ b/test/fixtures/es2019/expected.js
@@ -1,0 +1,7 @@
+try {
+    console.log('body of try statement');
+} catch {
+    console.log('optional catch binding');
+} finally {
+    console.log('in finalizer');
+}

--- a/test/fixtures/es2019/fixture.js
+++ b/test/fixtures/es2019/fixture.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+try {
+    console.log('body of try statement');
+    assert(true);
+} catch {
+    console.log('optional catch binding');
+    assert(false);
+} finally {
+    console.log('in finalizer');
+    assert(true);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,39 +1,39 @@
-/* global describe, it */
 'use strict';
 
 delete require.cache[require.resolve('../')];
-var fs = require('fs');
-var es = require('event-stream');
-var assert = require('power-assert');
-var Vinyl = require('vinyl');
-var unassert = require('../');
+const unassert = require('../');
+const fs = require('fs');
+const { join } = require('path');
+const es = require('event-stream');
+const assert = require('assert').strict;
+const Vinyl = require('vinyl');
 
-describe('gulp-unassert', function () {
-  ['es2018', 'es2019'].forEach(function (name) {
-    it(name + ' syntax', function (done) {
-      var stream = unassert();
-      var srcStream = new Vinyl({
-        path: process.cwd() + '/test/fixtures/' + name + '/fixture.js',
+describe('gulp-unassert', () => {
+  ['es2018', 'es2019'].forEach((name) => {
+    it(name + ' syntax', (done) => {
+      const stream = unassert();
+      const srcStream = new Vinyl({
+        path: join(process.cwd(), 'test', 'fixtures', name, 'fixture.js'),
         cwd: process.cwd(),
-        base: process.cwd() + '/test/fixtures/' + name,
-        contents: fs.createReadStream('test/fixtures/' + name + '/fixture.js')
+        base: join(process.cwd(), 'test', 'fixtures', name),
+        contents: fs.createReadStream(join('test', 'fixtures', name, 'fixture.js'))
       });
-      var expectedFile = new Vinyl({
-        path: process.cwd() + '/test/fixtures/' + name + '/expected.js',
+      const expectedFile = new Vinyl({
+        path: join(process.cwd(), 'test', 'fixtures', name, 'expected.js'),
         cwd: process.cwd(),
-        base: process.cwd() + '/test/fixtures/' + name,
-        contents: fs.readFileSync('test/fixtures/' + name + '/expected.js')
+        base: join(process.cwd(), 'test', 'fixtures', name),
+        contents: fs.readFileSync(join('test', 'fixtures', name, 'expected.js'))
       });
-      stream.on('error', function (err) {
+      stream.on('error', (err) => {
         assert(!err.message);
         done();
       });
-      stream.on('data', function (newFile) {
+      stream.on('data', (newFile) => {
         assert(newFile);
         assert(newFile.contents);
-        newFile.contents.pipe(es.wait(function (err, data) {
+        newFile.contents.pipe(es.wait((err, data) => {
           assert(!err);
-          assert.equal(data.toString('utf-8') + '\n', String(expectedFile.contents));
+          assert.equal(String(data.toString('utf-8')) + '\n', String(expectedFile.contents));
           done();
         }));
       });
@@ -42,25 +42,25 @@ describe('gulp-unassert', function () {
     });
   });
 
-  it('should produce expected file via buffer', function (done) {
-    var stream = unassert();
-    var srcFile = new Vinyl({
-      path: process.cwd() + '/test/fixtures/patterns/fixture.js',
+  it('should produce expected file via buffer', (done) => {
+    const stream = unassert();
+    const srcFile = new Vinyl({
+      path: join(process.cwd(), 'test', 'fixtures', 'patterns', 'fixture.js'),
       cwd: process.cwd(),
-      base: process.cwd() + '/test/fixtures/patterns',
-      contents: fs.readFileSync('test/fixtures/patterns/fixture.js')
+      base: join(process.cwd(), 'test', 'fixtures', 'patterns'),
+      contents: fs.readFileSync(join('test', 'fixtures', 'patterns', 'fixture.js'))
     });
-    var expectedFile = new Vinyl({
-      path: process.cwd() + '/test/fixtures/patterns/expected.js',
+    const expectedFile = new Vinyl({
+      path: join(process.cwd(), 'test', 'fixtures', 'patterns', 'expected.js'),
       cwd: process.cwd(),
-      base: process.cwd() + '/test/fixtures/patterns',
-      contents: fs.readFileSync('test/fixtures/patterns/expected.js')
+      base: join(process.cwd(), 'test', 'fixtures', 'patterns'),
+      contents: fs.readFileSync(join('test', 'fixtures', 'patterns', 'expected.js'))
     });
-    stream.on('error', function (err) {
+    stream.on('error', (err) => {
       assert(err);
       done(err);
     });
-    stream.on('data', function (newFile) {
+    stream.on('data', (newFile) => {
       assert(newFile);
       assert(newFile.contents);
       assert.equal(String(newFile.contents), String(expectedFile.contents));
@@ -70,28 +70,28 @@ describe('gulp-unassert', function () {
     stream.end();
   });
 
-  it('should produce expected file via stream', function (done) {
-    var stream = unassert();
-    var srcStream = new Vinyl({
-      path: process.cwd() + '/test/fixtures/patterns/fixture.js',
+  it('should produce expected file via stream', (done) => {
+    const stream = unassert();
+    const srcStream = new Vinyl({
+      path: join(process.cwd(), 'test', 'fixtures', 'patterns', 'fixture.js'),
       cwd: process.cwd(),
-      base: process.cwd() + '/test/fixtures/patterns',
-      contents: fs.createReadStream('test/fixtures/patterns/fixture.js')
+      base: join(process.cwd(), 'test', 'fixtures', 'patterns'),
+      contents: fs.createReadStream(join('test', 'fixtures', 'patterns', 'fixture.js'))
     });
-    var expectedFile = new Vinyl({
-      path: process.cwd() + '/test/fixtures/patterns/expected.js',
+    const expectedFile = new Vinyl({
+      path: join(process.cwd(), 'test', 'fixtures', 'patterns', 'expected.js'),
       cwd: process.cwd(),
-      base: process.cwd() + '/test/fixtures/patterns',
-      contents: fs.readFileSync('test/fixtures/patterns/expected.js')
+      base: join(process.cwd(), 'test', 'fixtures', 'patterns'),
+      contents: fs.readFileSync(join('test', 'fixtures', 'patterns', 'expected.js'))
     });
-    stream.on('error', function (err) {
+    stream.on('error', (err) => {
       assert(err);
       done();
     });
-    stream.on('data', function (newFile) {
+    stream.on('data', (newFile) => {
       assert(newFile);
       assert(newFile.contents);
-      newFile.contents.pipe(es.wait(function (err, data) {
+      newFile.contents.pipe(es.wait((err, data) => {
         assert(!err);
         assert.equal(data.toString('utf-8'), String(expectedFile.contents));
         done();
@@ -101,17 +101,17 @@ describe('gulp-unassert', function () {
     stream.end();
   });
 
-  describe('should not throw but emit error when the file has a syntax error', function () {
-    it('when file is Buffer', function (done) {
-      var stream = unassert();
-      var srcFile = new Vinyl({
-        path: process.cwd() + '/test/fixtures/syntax-error/fixture.js',
+  describe('should not throw but emit error when the file has a syntax error', () => {
+    it('when file is Buffer', (done) => {
+      const stream = unassert();
+      const srcFile = new Vinyl({
+        path: join(process.cwd(), 'test', 'fixtures', 'syntax-error', 'fixture.js'),
         cwd: process.cwd(),
-        base: process.cwd() + '/test/fixtures/syntax-error',
-        contents: fs.readFileSync('test/fixtures/syntax-error/fixture.js')
+        base: join(process.cwd(), 'test', 'fixtures', 'syntax-error'),
+        contents: fs.readFileSync(join('test', 'fixtures', 'syntax-error', 'fixture.js'))
       });
-      assert.doesNotThrow(function () {
-        stream.on('error', function (err) {
+      assert.doesNotThrow(() => {
+        stream.on('error', (err) => {
           assert(err);
           done();
         });
@@ -119,16 +119,16 @@ describe('gulp-unassert', function () {
         stream.end();
       });
     });
-    it('when file is Stream', function (done) {
-      var stream = unassert();
-      var srcStream = new Vinyl({
-        path: process.cwd() + '/test/fixtures/syntax-error/fixture.js',
+    it('when file is Stream', (done) => {
+      const stream = unassert();
+      const srcStream = new Vinyl({
+        path: join(process.cwd(), 'test', 'fixtures', 'syntax-error', 'fixture.js'),
         cwd: process.cwd(),
-        base: process.cwd() + '/test/fixtures/syntax-error',
-        contents: fs.createReadStream('test/fixtures/syntax-error/fixture.js')
+        base: join(process.cwd(), 'test', 'fixtures', 'syntax-error'),
+        contents: fs.createReadStream(join('test', 'fixtures', 'syntax-error', 'fixture.js'))
       });
-      assert.doesNotThrow(function () {
-        stream.on('error', function (err) {
+      assert.doesNotThrow(() => {
+        stream.on('error', (err) => {
           assert(err);
           done();
         });
@@ -138,14 +138,14 @@ describe('gulp-unassert', function () {
     });
   });
 
-  describe('SourceMap support', function () {
-    it('with initial sourceMap created by gulp-sourcemaps', function (done) {
-      var stream = unassert();
-      var srcFileContents = fs.readFileSync('test/fixtures/patterns/fixture.js');
-      var srcFile = new Vinyl({
-        path: process.cwd() + '/test/fixtures/patterns/fixture.js',
+  describe('SourceMap support', () => {
+    it('with initial sourceMap created by gulp-sourcemaps', (done) => {
+      const stream = unassert();
+      const srcFileContents = fs.readFileSync(join('test', 'fixtures', 'patterns', 'fixture.js'));
+      const srcFile = new Vinyl({
+        path: join(process.cwd(), 'test', 'fixtures', 'patterns', 'fixture.js'),
         cwd: process.cwd(),
-        base: process.cwd() + '/test/fixtures/patterns',
+        base: join(process.cwd(), 'test', 'fixtures', 'patterns'),
         contents: srcFileContents
       });
       // simulate initial raw map created by gulp-sourcemaps
@@ -157,14 +157,15 @@ describe('gulp-unassert', function () {
         sources: [srcFile.relative],
         sourcesContent: [srcFileContents.toString('utf8')]
       };
-      stream.on('error', function (err) {
+      stream.on('error', (err) => {
         assert(err);
         done(err);
       });
-      stream.on('data', function (newFile) {
+      stream.on('data', (newFile) => {
         assert(newFile);
         assert(newFile.contents);
-        assert.equal(newFile.contents.toString(), fs.readFileSync('test/fixtures/patterns/expected.js', 'utf8'));
+        const expectedContent = fs.readFileSync(join('test', 'fixtures', 'patterns', 'expected.js'), 'utf8');
+        assert.equal(newFile.contents.toString(), expectedContent);
         assert(newFile.sourceMap, 'push file.sourceMap to downstream');
         assert.deepEqual(newFile.sourceMap, {
           version: 3,
@@ -186,14 +187,14 @@ describe('gulp-unassert', function () {
       stream.end();
     });
 
-    it('with upstream sourceMap', function (done) {
-      var stream = unassert();
-      var originalFileContents = fs.readFileSync('test/fixtures/coffee/fixture.coffee', 'utf8');
-      var srcFile = new Vinyl({
-        path: process.cwd() + '/test/fixtures/coffee/fixture.js',
+    it('with upstream sourceMap', (done) => {
+      const stream = unassert();
+      const originalFileContents = fs.readFileSync(join(process.cwd(), 'test', 'fixtures', 'coffee', 'fixture.coffee'), 'utf8');
+      const srcFile = new Vinyl({
+        path: join(process.cwd(), 'test', 'fixtures', 'coffee', 'fixture.js'),
         cwd: process.cwd(),
-        base: process.cwd() + '/test/fixtures/coffee',
-        contents: fs.readFileSync('test/fixtures/coffee/fixture.js')
+        base: join(process.cwd(), 'test', 'fixtures', 'coffee'),
+        contents: fs.readFileSync(join(process.cwd(), 'test', 'fixtures', 'coffee', 'fixture.js'))
       });
       srcFile.sourceMap = {
         version: 3,
@@ -204,14 +205,15 @@ describe('gulp-unassert', function () {
         sourceRoot: '',
         sourcesContent: [originalFileContents]
       };
-      stream.on('error', function (err) {
+      stream.on('error', (err) => {
         assert(err);
         done(err);
       });
-      stream.on('data', function (newFile) {
+      stream.on('data', (newFile) => {
         assert(newFile);
         assert(newFile.contents);
-        assert.equal(newFile.contents.toString() + '\n', fs.readFileSync('test/fixtures/coffee/expected.js', 'utf8'));
+        const expectedContent = fs.readFileSync(join(process.cwd(), 'test', 'fixtures', 'coffee', 'expected.js'), 'utf8');
+        assert.equal(newFile.contents.toString() + '\n', expectedContent);
         assert(newFile.sourceMap, 'push file.sourceMap to downstream');
         assert.deepEqual(newFile.sourceMap, {
           version: 3,

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-/*global describe, it*/
+/* global describe, it */
 'use strict';
 
 delete require.cache[require.resolve('../')];
@@ -9,223 +9,221 @@ var Vinyl = require('vinyl');
 var unassert = require('../');
 
 describe('gulp-unassert', function () {
-
-    it('ES2018 syntax', function (done) {
-        var stream = unassert();
-        var srcStream = new Vinyl({
-            path: process.cwd() + "/test/fixtures/es2018/fixture.js",
-            cwd: process.cwd(),
-            base: process.cwd() + "/test/fixtures/es2018",
-            contents: fs.createReadStream('test/fixtures/es2018/fixture.js')
-        });
-        var expectedFile = new Vinyl({
-            path: process.cwd() + '/test/fixtures/es2018/expected.js',
-            cwd: process.cwd(),
-            base: process.cwd() + '/test/fixtures/es2018',
-            contents: fs.readFileSync('test/fixtures/es2018/expected.js')
-        });
-        stream.on('error', function(err) {
-            assert(!err.message);
-            done();
-        });
-        stream.on('data', function (newFile) {
-            assert(newFile);
-            assert(newFile.contents);
-            newFile.contents.pipe(es.wait(function(err, data) {
-                assert(!err);
-                assert.equal(data.toString('utf-8') + '\n', String(expectedFile.contents));
-                done();
-            }));
-        });
-        stream.write(srcStream);
-        stream.end();
+  it('ES2018 syntax', function (done) {
+    var stream = unassert();
+    var srcStream = new Vinyl({
+      path: process.cwd() + '/test/fixtures/es2018/fixture.js',
+      cwd: process.cwd(),
+      base: process.cwd() + '/test/fixtures/es2018',
+      contents: fs.createReadStream('test/fixtures/es2018/fixture.js')
     });
+    var expectedFile = new Vinyl({
+      path: process.cwd() + '/test/fixtures/es2018/expected.js',
+      cwd: process.cwd(),
+      base: process.cwd() + '/test/fixtures/es2018',
+      contents: fs.readFileSync('test/fixtures/es2018/expected.js')
+    });
+    stream.on('error', function (err) {
+      assert(!err.message);
+      done();
+    });
+    stream.on('data', function (newFile) {
+      assert(newFile);
+      assert(newFile.contents);
+      newFile.contents.pipe(es.wait(function (err, data) {
+        assert(!err);
+        assert.equal(data.toString('utf-8') + '\n', String(expectedFile.contents));
+        done();
+      }));
+    });
+    stream.write(srcStream);
+    stream.end();
+  });
 
-    
-    it('should produce expected file via buffer', function (done) {
-        var stream = unassert();
-        var srcFile = new Vinyl({
-            path: process.cwd() + "/test/fixtures/patterns/fixture.js",
-            cwd: process.cwd(),
-            base: process.cwd() + "/test/fixtures/patterns",
-            contents: fs.readFileSync('test/fixtures/patterns/fixture.js')
-        });
-        var expectedFile = new Vinyl({
-            path: process.cwd() + '/test/fixtures/patterns/expected.js',
-            cwd: process.cwd(),
-            base: process.cwd() + '/test/fixtures/patterns',
-            contents: fs.readFileSync('test/fixtures/patterns/expected.js')
-        });
-        stream.on('error', function(err) {
-            assert(err);
-            done(err);
-        });
-        stream.on('data', function (newFile) {
-            assert(newFile);
-            assert(newFile.contents);
-            assert.equal(String(newFile.contents), String(expectedFile.contents));
-            done();
+  it('should produce expected file via buffer', function (done) {
+    var stream = unassert();
+    var srcFile = new Vinyl({
+      path: process.cwd() + '/test/fixtures/patterns/fixture.js',
+      cwd: process.cwd(),
+      base: process.cwd() + '/test/fixtures/patterns',
+      contents: fs.readFileSync('test/fixtures/patterns/fixture.js')
+    });
+    var expectedFile = new Vinyl({
+      path: process.cwd() + '/test/fixtures/patterns/expected.js',
+      cwd: process.cwd(),
+      base: process.cwd() + '/test/fixtures/patterns',
+      contents: fs.readFileSync('test/fixtures/patterns/expected.js')
+    });
+    stream.on('error', function (err) {
+      assert(err);
+      done(err);
+    });
+    stream.on('data', function (newFile) {
+      assert(newFile);
+      assert(newFile.contents);
+      assert.equal(String(newFile.contents), String(expectedFile.contents));
+      done();
+    });
+    stream.write(srcFile);
+    stream.end();
+  });
+
+  it('should produce expected file via stream', function (done) {
+    var stream = unassert();
+    var srcStream = new Vinyl({
+      path: process.cwd() + '/test/fixtures/patterns/fixture.js',
+      cwd: process.cwd(),
+      base: process.cwd() + '/test/fixtures/patterns',
+      contents: fs.createReadStream('test/fixtures/patterns/fixture.js')
+    });
+    var expectedFile = new Vinyl({
+      path: process.cwd() + '/test/fixtures/patterns/expected.js',
+      cwd: process.cwd(),
+      base: process.cwd() + '/test/fixtures/patterns',
+      contents: fs.readFileSync('test/fixtures/patterns/expected.js')
+    });
+    stream.on('error', function (err) {
+      assert(err);
+      done();
+    });
+    stream.on('data', function (newFile) {
+      assert(newFile);
+      assert(newFile.contents);
+      newFile.contents.pipe(es.wait(function (err, data) {
+        assert(!err);
+        assert.equal(data.toString('utf-8'), String(expectedFile.contents));
+        done();
+      }));
+    });
+    stream.write(srcStream);
+    stream.end();
+  });
+
+  describe('should not throw but emit error when the file has a syntax error', function () {
+    it('when file is Buffer', function (done) {
+      var stream = unassert();
+      var srcFile = new Vinyl({
+        path: process.cwd() + '/test/fixtures/syntax-error/fixture.js',
+        cwd: process.cwd(),
+        base: process.cwd() + '/test/fixtures/syntax-error',
+        contents: fs.readFileSync('test/fixtures/syntax-error/fixture.js')
+      });
+      assert.doesNotThrow(function () {
+        stream.on('error', function (err) {
+          assert(err);
+          done();
         });
         stream.write(srcFile);
         stream.end();
+      });
     });
-
-    it('should produce expected file via stream', function (done) {
-        var stream = unassert();
-        var srcStream = new Vinyl({
-            path: process.cwd() + "/test/fixtures/patterns/fixture.js",
-            cwd: process.cwd(),
-            base: process.cwd() + "/test/fixtures/patterns",
-            contents: fs.createReadStream('test/fixtures/patterns/fixture.js')
-        });
-        var expectedFile = new Vinyl({
-            path: process.cwd() + '/test/fixtures/patterns/expected.js',
-            cwd: process.cwd(),
-            base: process.cwd() + '/test/fixtures/patterns',
-            contents: fs.readFileSync('test/fixtures/patterns/expected.js')
-        });
-        stream.on('error', function(err) {
-            assert(err);
-            done();
-        });
-        stream.on('data', function (newFile) {
-            assert(newFile);
-            assert(newFile.contents);
-            newFile.contents.pipe(es.wait(function(err, data) {
-                assert(!err);
-                assert.equal(data.toString('utf-8'), String(expectedFile.contents));
-                done();
-            }));
+    it('when file is Stream', function (done) {
+      var stream = unassert();
+      var srcStream = new Vinyl({
+        path: process.cwd() + '/test/fixtures/syntax-error/fixture.js',
+        cwd: process.cwd(),
+        base: process.cwd() + '/test/fixtures/syntax-error',
+        contents: fs.createReadStream('test/fixtures/syntax-error/fixture.js')
+      });
+      assert.doesNotThrow(function () {
+        stream.on('error', function (err) {
+          assert(err);
+          done();
         });
         stream.write(srcStream);
         stream.end();
+      });
+    });
+  });
+
+  describe('SourceMap support', function () {
+    it('with initial sourceMap created by gulp-sourcemaps', function (done) {
+      var stream = unassert();
+      var srcFileContents = fs.readFileSync('test/fixtures/patterns/fixture.js');
+      var srcFile = new Vinyl({
+        path: process.cwd() + '/test/fixtures/patterns/fixture.js',
+        cwd: process.cwd(),
+        base: process.cwd() + '/test/fixtures/patterns',
+        contents: srcFileContents
+      });
+      // simulate initial raw map created by gulp-sourcemaps
+      srcFile.sourceMap = {
+        version: 3,
+        file: srcFile.relative,
+        names: [],
+        mappings: '',
+        sources: [srcFile.relative],
+        sourcesContent: [srcFileContents.toString('utf8')]
+      };
+      stream.on('error', function (err) {
+        assert(err);
+        done(err);
+      });
+      stream.on('data', function (newFile) {
+        assert(newFile);
+        assert(newFile.contents);
+        assert.equal(newFile.contents.toString(), fs.readFileSync('test/fixtures/patterns/expected.js', 'utf8'));
+        assert(newFile.sourceMap, 'push file.sourceMap to downstream');
+        assert.deepEqual(newFile.sourceMap, {
+          version: 3,
+          sources: [
+            'fixture.js'
+          ],
+          names: [
+            'add',
+            'a',
+            'b'
+          ],
+          mappings: 'AAAA;AAIA,SAASA,GAAT,CAAcC,CAAd,EAAiBC,CAAjB,EAAoB;AAAA,IAqDhB,OAAOD,CAAA,GAAIC,CAAX,CArDgB;AAAA',
+          file: 'fixture.js',
+          sourcesContent: [srcFileContents.toString('utf8')]
+        });
+        done();
+      });
+      stream.write(srcFile);
+      stream.end();
     });
 
-    describe('should not throw but emit error when the file has a syntax error', function () {
-        it('when file is Buffer', function (done) {
-            var stream = unassert();
-            var srcFile = new Vinyl({
-                path: process.cwd() + "/test/fixtures/syntax-error/fixture.js",
-                cwd: process.cwd(),
-                base: process.cwd() + "/test/fixtures/syntax-error",
-                contents: fs.readFileSync("test/fixtures/syntax-error/fixture.js")
-            });
-            assert.doesNotThrow(function() {
-                stream.on("error", function(err) {
-                    assert(err);
-                    done();
-                });
-                stream.write(srcFile);
-                stream.end();
-            });
+    it('with upstream sourceMap', function (done) {
+      var stream = unassert();
+      var originalFileContents = fs.readFileSync('test/fixtures/coffee/fixture.coffee', 'utf8');
+      var srcFile = new Vinyl({
+        path: process.cwd() + '/test/fixtures/coffee/fixture.js',
+        cwd: process.cwd(),
+        base: process.cwd() + '/test/fixtures/coffee',
+        contents: fs.readFileSync('test/fixtures/coffee/fixture.js')
+      });
+      srcFile.sourceMap = {
+        version: 3,
+        sources: ['fixture.coffee'],
+        names: [],
+        mappings: 'AAAA,IAAA;;AAAA,MAAA,GAAS,OAAA,CAAQ,QAAR;;AAET,GAAA,GAAM,SAAC,CAAD,EAAI,CAAJ;EACJ,OAAO,CAAC,MAAR,CAAe,OAAO,CAAP,KAAY,QAA3B;EACA,MAAA,CAAO,CAAC,KAAA,CAAM,CAAN,CAAR;EACA,MAAM,CAAC,KAAP,CAAa,OAAO,CAApB,EAAuB,QAAvB;EACA,MAAM,CAAC,EAAP,CAAU,CAAC,KAAA,CAAM,CAAN,CAAX;SACA,CAAA,GAAI;AALA',
+        file: 'fixture.js',
+        sourceRoot: '',
+        sourcesContent: [originalFileContents]
+      };
+      stream.on('error', function (err) {
+        assert(err);
+        done(err);
+      });
+      stream.on('data', function (newFile) {
+        assert(newFile);
+        assert(newFile.contents);
+        assert.equal(newFile.contents.toString() + '\n', fs.readFileSync('test/fixtures/coffee/expected.js', 'utf8'));
+        assert(newFile.sourceMap, 'push file.sourceMap to downstream');
+        assert.deepEqual(newFile.sourceMap, {
+          version: 3,
+          sources: ['fixture.coffee'],
+          names: [],
+          mappings: 'AAAA,IAAA,GAAA,EAAA,MAAA;AAEA,GAAA,GAAM,UAAC,CAAD,EAAI,CAAJ,EAAA;AAAA,WAKJ,CAAA,GAAI,EALA;AAAA,CAAN',
+          file: 'fixture.js',
+          sourceRoot: '',
+          sourcesContent: [originalFileContents]
         });
-        it('when file is Stream', function (done) {
-            var stream = unassert();
-            var srcStream = new Vinyl({
-                path: process.cwd() + "/test/fixtures/syntax-error/fixture.js",
-                cwd: process.cwd(),
-                base: process.cwd() + "/test/fixtures/syntax-error",
-                contents: fs.createReadStream("test/fixtures/syntax-error/fixture.js")
-            });
-            assert.doesNotThrow(function() {
-                stream.on("error", function(err) {
-                    assert(err);
-                    done();
-                });
-                stream.write(srcStream);
-                stream.end();
-            });
-        });
+        done();
+      });
+      stream.write(srcFile);
+      stream.end();
     });
-
-    describe('SourceMap support', function () {
-        it('with initial sourceMap created by gulp-sourcemaps', function (done) {
-            var stream = unassert();
-            var srcFileContents = fs.readFileSync('test/fixtures/patterns/fixture.js');
-            var srcFile = new Vinyl({
-                path: process.cwd() + "/test/fixtures/patterns/fixture.js",
-                cwd: process.cwd(),
-                base: process.cwd() + "/test/fixtures/patterns",
-                contents: srcFileContents
-            });
-            // simulate initial raw map created by gulp-sourcemaps
-            srcFile.sourceMap = {
-                version : 3,
-                file: srcFile.relative,
-                names: [],
-                mappings: '',
-                sources: [ srcFile.relative ],
-                sourcesContent: [ srcFileContents.toString('utf8') ]
-            };
-            stream.on("error", function(err) {
-                assert(err);
-                done(err);
-            });
-            stream.on("data", function (newFile) {
-                assert(newFile);
-                assert(newFile.contents);
-                assert.equal(newFile.contents.toString(), fs.readFileSync('test/fixtures/patterns/expected.js', 'utf8'));
-                assert(newFile.sourceMap, 'push file.sourceMap to downstream');
-                assert.deepEqual(newFile.sourceMap, {
-                    version: 3,
-                    sources: [
-                        'fixture.js'
-                    ],
-                    names: [
-                        'add',
-                        'a',
-                        'b'
-                    ],
-                    mappings: 'AAAA;AAIA,SAASA,GAAT,CAAcC,CAAd,EAAiBC,CAAjB,EAAoB;AAAA,IAqDhB,OAAOD,CAAA,GAAIC,CAAX,CArDgB;AAAA',
-                    file: 'fixture.js',
-                    sourcesContent: [ srcFileContents.toString('utf8') ] 
-                });
-                done();
-            });
-            stream.write(srcFile);
-            stream.end();
-        });
-
-        it('with upstream sourceMap', function (done) {
-            var stream = unassert();
-            var originalFileContents = fs.readFileSync('test/fixtures/coffee/fixture.coffee', 'utf8');
-            var srcFile = new Vinyl({
-                path: process.cwd() + "/test/fixtures/coffee/fixture.js",
-                cwd: process.cwd(),
-                base: process.cwd() + "/test/fixtures/coffee",
-                contents: fs.readFileSync('test/fixtures/coffee/fixture.js')
-            });
-            srcFile.sourceMap = {
-                version: 3,
-                sources: [ 'fixture.coffee' ],
-                names: [],
-                mappings: 'AAAA,IAAA;;AAAA,MAAA,GAAS,OAAA,CAAQ,QAAR;;AAET,GAAA,GAAM,SAAC,CAAD,EAAI,CAAJ;EACJ,OAAO,CAAC,MAAR,CAAe,OAAO,CAAP,KAAY,QAA3B;EACA,MAAA,CAAO,CAAC,KAAA,CAAM,CAAN,CAAR;EACA,MAAM,CAAC,KAAP,CAAa,OAAO,CAApB,EAAuB,QAAvB;EACA,MAAM,CAAC,EAAP,CAAU,CAAC,KAAA,CAAM,CAAN,CAAX;SACA,CAAA,GAAI;AALA',
-                file: 'fixture.js',
-                sourceRoot: '',
-                sourcesContent: [ originalFileContents ]
-            };
-            stream.on("error", function(err) {
-                assert(err);
-                done(err);
-            });
-            stream.on("data", function (newFile) {
-                assert(newFile);
-                assert(newFile.contents);
-                assert.equal(newFile.contents.toString() + '\n', fs.readFileSync('test/fixtures/coffee/expected.js', 'utf8'));
-                assert(newFile.sourceMap, 'push file.sourceMap to downstream');
-                assert.deepEqual(newFile.sourceMap, {
-                    version: 3,
-                    sources: [ 'fixture.coffee' ],
-                    names: [],
-                    mappings: 'AAAA,IAAA,GAAA,EAAA,MAAA;AAEA,GAAA,GAAM,UAAC,CAAD,EAAI,CAAJ,EAAA;AAAA,WAKJ,CAAA,GAAI,EALA;AAAA,CAAN',
-                    file: 'fixture.js',
-                    sourceRoot: '',
-                    sourcesContent: [ originalFileContents ] 
-                });
-                done();
-            });
-            stream.write(srcFile);
-            stream.end();
-        });
-    });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@ const assert = require('assert').strict;
 const Vinyl = require('vinyl');
 
 describe('gulp-unassert', () => {
-  ['es2018', 'es2019'].forEach((name) => {
+  for (const name of ['es2018', 'es2019']) {
     it(name + ' syntax', (done) => {
       const stream = unassert();
       const srcStream = new Vinyl({
@@ -40,7 +40,7 @@ describe('gulp-unassert', () => {
       stream.write(srcStream);
       stream.end();
     });
-  });
+  }
 
   it('should produce expected file via buffer', (done) => {
     const stream = unassert();

--- a/test/test.js
+++ b/test/test.js
@@ -9,35 +9,37 @@ var Vinyl = require('vinyl');
 var unassert = require('../');
 
 describe('gulp-unassert', function () {
-  it('ES2018 syntax', function (done) {
-    var stream = unassert();
-    var srcStream = new Vinyl({
-      path: process.cwd() + '/test/fixtures/es2018/fixture.js',
-      cwd: process.cwd(),
-      base: process.cwd() + '/test/fixtures/es2018',
-      contents: fs.createReadStream('test/fixtures/es2018/fixture.js')
-    });
-    var expectedFile = new Vinyl({
-      path: process.cwd() + '/test/fixtures/es2018/expected.js',
-      cwd: process.cwd(),
-      base: process.cwd() + '/test/fixtures/es2018',
-      contents: fs.readFileSync('test/fixtures/es2018/expected.js')
-    });
-    stream.on('error', function (err) {
-      assert(!err.message);
-      done();
-    });
-    stream.on('data', function (newFile) {
-      assert(newFile);
-      assert(newFile.contents);
-      newFile.contents.pipe(es.wait(function (err, data) {
-        assert(!err);
-        assert.equal(data.toString('utf-8') + '\n', String(expectedFile.contents));
+  ['es2018', 'es2019'].forEach(function (name) {
+    it(name + ' syntax', function (done) {
+      var stream = unassert();
+      var srcStream = new Vinyl({
+        path: process.cwd() + '/test/fixtures/' + name + '/fixture.js',
+        cwd: process.cwd(),
+        base: process.cwd() + '/test/fixtures/' + name,
+        contents: fs.createReadStream('test/fixtures/' + name + '/fixture.js')
+      });
+      var expectedFile = new Vinyl({
+        path: process.cwd() + '/test/fixtures/' + name + '/expected.js',
+        cwd: process.cwd(),
+        base: process.cwd() + '/test/fixtures/' + name,
+        contents: fs.readFileSync('test/fixtures/' + name + '/expected.js')
+      });
+      stream.on('error', function (err) {
+        assert(!err.message);
         done();
-      }));
+      });
+      stream.on('data', function (newFile) {
+        assert(newFile);
+        assert(newFile.contents);
+        newFile.contents.pipe(es.wait(function (err, data) {
+          assert(!err);
+          assert.equal(data.toString('utf-8') + '\n', String(expectedFile.contents));
+          done();
+        }));
+      });
+      stream.write(srcStream);
+      stream.end();
     });
-    stream.write(srcStream);
-    stream.end();
   });
 
   it('should produce expected file via buffer', function (done) {


### PR DESCRIPTION
Support ES2019 and ES2020 syntax

BREAKING CHANGE: drop support for old Node versions (Node < 10)
Users of old Nodes should install gulp-unassert@1.x